### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Global configuration is stored in `config/application.yml` file, the relevant pa
 |------------------------|-----------------------|--------------------------------------------------------------------------------|
 | ALFRESCO_BASE_PATH     | http://localhost:8080 | scheme, host and port of the Alfresco server                                   |
 | ALFRESCO_USERNAME      | admin                 | Alfresco user                                                                  |
-| ALFRESCO_PASSORD       | admin                 | password for the Alfresco user                                                 |
+| ALFRESCO_PASSWORD      | admin                 | password for the Alfresco user                                                 |
 | QUEUE_SIZE             | 1000                  | size of the node-uuid queue                                                    |
 | CONSUMER_THREADS       | 4                     | number of consumers that are executed simultaneously                           |
 | CONSUMER_TIMEOUT       | 5000                  | milliseconds after which a consumer gives up waiting for data in the queue |


### PR DESCRIPTION
## Summary
- fix a typo in environment variable description in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6842895c1ee4832f8e1d550672f83de8