### PR TITLE
Switch to DefaultParser in CLI parser

### DIFF
--- a/src/main/java/org/saidone/utils/AnpCommandLineParser.java
+++ b/src/main/java/org/saidone/utils/AnpCommandLineParser.java
@@ -20,7 +20,12 @@ package org.saidone.utils;
 
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.cli.*;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 import org.apache.logging.log4j.util.Strings;
 
 @UtilityClass
@@ -36,7 +41,7 @@ public class AnpCommandLineParser {
                 .desc("config file").build();
         options.addOption(configOption);
         CommandLine cmd;
-        var parser = new BasicParser();
+        var parser = new DefaultParser();
         var helper = new HelpFormatter();
         var configFileName = Strings.EMPTY;
         try {


### PR DESCRIPTION
## Summary
- replace deprecated `BasicParser` with `DefaultParser`
- import specific Commons CLI classes

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684433a75fec832fb4fa63447c43664b