### PR TITLE
Add MoveNodeProcessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ Apply a list of permissions and set inheritance flag to the collected nodes:
   }
 }
 ```
+#### MoveNodeProcessor
+Sposta i nodi raccolti in una nuova cartella specificando il `targetParentId` o
+il `targetPath` di destinazione:
+```json
+"processor": {
+  "name": "MoveNodeProcessor",
+  "args": {
+    "targetParentId": "e72b6596-ec2e-4279-b490-3a03b119d8de"
+  }
+}
+```
 #### Custom processors
 Custom processors can be easily created by extending the AbstractNodeProcessor and overriding the `processNode` method:
 ```java

--- a/src/main/java/org/saidone/processors/MoveNodeProcessor.java
+++ b/src/main/java/org/saidone/processors/MoveNodeProcessor.java
@@ -1,0 +1,26 @@
+package org.saidone.processors;
+
+import lombok.extern.slf4j.Slf4j;
+import org.alfresco.core.model.NodeBodyMove;
+import org.saidone.model.config.ProcessorConfig;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class MoveNodeProcessor extends AbstractNodeProcessor {
+
+    @Override
+    public void processNode(String nodeId, ProcessorConfig config) {
+        var moveBody = new NodeBodyMove();
+        if (config.getArg("targetParentId") != null) {
+            moveBody.setTargetParentId((String) config.getArg("targetParentId"));
+        }
+        if (config.getArg("targetPath") != null) {
+            moveBody.setTargetPath((String) config.getArg("targetPath"));
+        }
+        log.debug("moving node --> {} to --> {}", nodeId, moveBody);
+        if (config.getReadOnly() != null && !config.getReadOnly()) {
+            nodesApi.moveNode(nodeId, moveBody, null, null);
+        }
+    }
+}

--- a/src/main/resources/example-move-node.json
+++ b/src/main/resources/example-move-node.json
@@ -1,0 +1,15 @@
+{
+  "collector": {
+    "name": "NodeListCollector",
+    "args": {
+      "nodeListFile": "nodes.txt"
+    }
+  },
+  "processor": {
+    "name": "MoveNodeProcessor",
+    "args": {
+      "targetParentId": "destination-node-id"
+    },
+    "readOnly": true
+  }
+}


### PR DESCRIPTION
## Summary
- implement MoveNodeProcessor extending AbstractNodeProcessor
- allow moving by `targetParentId` or `targetPath`
- provide sample config
- document new processor in README

## Testing
- `mvn -q test` *(fails: Could not resolve Alfresco dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6848a52aabe4832fbf15cab95a6a9aa4