### PR TITLE
Add Javadoc publishing workflow

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,0 +1,39 @@
+name: Publish Javadoc
+
+on:
+  push:
+    branches: ["master"]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      - name: Generate Javadoc
+        run: mvn -B -DskipTests -Dlicense.skip=true javadoc:javadoc
+
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: target/site/apidocs
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ _Do things with nodes._
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 ![Java CI](https://github.com/saidone75/alfresco-node-processor/actions/workflows/build.yml/badge.svg)
 ![CodeQL](https://github.com/saidone75/alfresco-node-processor/actions/workflows/codeql.yml/badge.svg)
+[Javadoc](https://saidone75.github.io/alfresco-node-processor/)
 
 A modern, threaded and easily customizable Spring Boot Application that - given a means for collecting nodes - do something with them.
 


### PR DESCRIPTION
## Summary
- generate Javadoc and deploy it on GitHub Pages using a new workflow
- link the generated documentation in the README

## Testing
- `mvn -B -ntp test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_684e718b52e0832f851d149f36799c64