### PR TITLE
Add download processor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,15 @@ Think about this as a template for your application.
 
 Pull requests are welcome!
 ## Features
-- Built-in collectors for queries, node lists and tree traversal
-- Built-in processors for deleting, moving, setting properties and permissions
+- `QueryNodeCollector` executes Alfresco FTS queries
+- `NodeListCollector` reads node IDs from a file
+- `NodeTreeCollector` walks the repository tree
+- `DeleteNodeProcessor` deletes or trashes nodes
+- `MoveNodeProcessor` relocates nodes under a new parent
+- `AddAspectsAndSetPropertiesProcessor` adds aspects and properties
+- `SetPermissionsProcessor` applies permissions and inheritance
+- `DownloadNodeProcessor` saves node content and metadata to the filesystem
+- `ChainingNodeProcessor` executes multiple processors sequentially
 - Queue based architecture with configurable consumer threads
 - Easily extensible by implementing `AbstractNodeCollector` and `AbstractNodeProcessor`
 
@@ -120,6 +127,16 @@ Move collected nodes to a new folder identified either by its node-id or by the 
   "name": "MoveNodeProcessor",
   "args": {
     "target-parent-id": "e72b6596-ec2e-4279-b490-3a03b119d8de"
+  }
+}
+```
+#### DownloadNodeProcessor
+Download node content and metadata to a local directory in a format compatible with bulk import:
+```json
+"processor": {
+  "name": "DownloadNodeProcessor",
+  "args": {
+    "output-dir": "/tmp/export"
   }
 }
 ```


### PR DESCRIPTION
## Summary
- mention DownloadNodeProcessor and ChainingNodeProcessor in README features list
- document DownloadNodeProcessor usage
- detail every built-in collector and processor in the features section

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526e72a22c832fb3c2da1ca0d59558