### PR TITLE
Add Javadoc for Alfresco bulk model classes

### DIFF
--- a/src/main/java/org/saidone/model/alfresco/bulk/Entry.java
+++ b/src/main/java/org/saidone/model/alfresco/bulk/Entry.java
@@ -25,6 +25,11 @@ import lombok.Data;
 
 import java.io.Serializable;
 
+/**
+ * Single metadata entry used in the Alfresco bulk import format. The
+ * {@code key} attribute represents the property name while the element text
+ * holds the value that should be assigned to that property.
+ */
 @AllArgsConstructor
 @Data
 public class Entry {

--- a/src/main/java/org/saidone/model/alfresco/bulk/Properties.java
+++ b/src/main/java/org/saidone/model/alfresco/bulk/Properties.java
@@ -27,6 +27,10 @@ import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 
+/**
+ * Container for a collection of {@link Entry} objects that represent node
+ * properties for bulk metadata import.
+ */
 @Data
 @JacksonXmlRootElement(localName = "properties")
 public class Properties {

--- a/src/main/java/org/saidone/model/alfresco/bulk/Property.java
+++ b/src/main/java/org/saidone/model/alfresco/bulk/Property.java
@@ -21,6 +21,10 @@ package org.saidone.model.alfresco.bulk;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * Definition of a property supported by the bulk import. This can be used to
+ * describe available metadata fields when constructing bulk data sets.
+ */
 @Builder
 @Data
 public class Property {


### PR DESCRIPTION
## Summary
- document the bulk metadata model classes

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.alfresco:alfresco-java-sdk-samples)*

------
https://chatgpt.com/codex/tasks/task_e_685293e10dfc832fb37c4f4d85aaadaa