### PR TITLE
Add global read-only aspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Java and Maven required
 look at the `build.sh` or `build.bat` scripts for creating a convenient distribution package.
 ## Application global config
 Global configuration is stored in `config/application.yml` file, the relevant parameters are:
+The property `application.read-only` controls whether processors actually execute write operations. Set it to `false` to enable updates.
 
 | Parameter/env variable | Default value         | Purpose                                                                        |
 |------------------------|-----------------------|--------------------------------------------------------------------------------|
@@ -188,6 +189,7 @@ Global configuration is stored in `config/application.yml` file, the relevant pa
 | QUEUE_SIZE             | 1000                  | size of the node-uuid queue                                                    |
 | CONSUMER_THREADS       | 4                     | number of consumers that are executed simultaneously                           |
 | CONSUMER_TIMEOUT       | 5000                  | milliseconds after which a consumer gives up waiting for data in the queue |
+| READ_ONLY              | true                  | when true, mutating operations on nodes are skipped |
 ## Testing
 For integration tests just change configuration and point it to an existing Alfresco installation, or use `alfresco.(sh|bat)` script to start it with docker.
 ## Run

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/org/saidone/AlfrescoNodeProcessorApplicationRunner.java
+++ b/src/main/java/org/saidone/AlfrescoNodeProcessorApplicationRunner.java
@@ -59,6 +59,9 @@ public class AlfrescoNodeProcessorApplicationRunner implements CommandLineRunner
     @Value("${application.consumer-threads}")
     private int consumerThreads;
 
+    @Value("${application.read-only:true}")
+    private boolean readOnly;
+
     /**
      * Executes the collectors and processors defined by the configuration.
      *
@@ -77,11 +80,10 @@ public class AlfrescoNodeProcessorApplicationRunner implements CommandLineRunner
         var config = AlfrescoNodeProcessorUtils.loadConfig(configFileName);
 
         // log mode
-        if (config.getProcessor().getReadOnly() != null && !config.getProcessor().getReadOnly())
-            log.warn("READ-WRITE mode");
-        else {
-            config.getProcessor().setReadOnly(Boolean.TRUE);
+        if (readOnly) {
             log.warn("READ-ONLY mode");
+        } else {
+            log.warn("READ-WRITE mode");
         }
 
         // producer(s)

--- a/src/main/java/org/saidone/aspects/NodesApiReadOnlyAspect.java
+++ b/src/main/java/org/saidone/aspects/NodesApiReadOnlyAspect.java
@@ -1,0 +1,38 @@
+package org.saidone.aspects;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+/**
+ * Aspect that prevents write operations on Alfresco when the application
+ * is configured in read-only mode.
+ */
+@Aspect
+@Component
+@Slf4j
+public class NodesApiReadOnlyAspect {
+
+    @Value("${application.read-only:true}")
+    private boolean readOnly;
+
+    @Around(
+        "execution(* org.alfresco.core.handler.NodesApi.create*(..)) || " +
+        "execution(* org.alfresco.core.handler.NodesApi.update*(..)) || " +
+        "execution(* org.alfresco.core.handler.NodesApi.delete*(..)) || " +
+        "execution(* org.alfresco.core.handler.NodesApi.move*(..)) || " +
+        "execution(* org.alfresco.core.handler.NodesApi.set*(..))")
+    public Object enforceReadOnly(ProceedingJoinPoint pjp) throws Throwable {
+        if (readOnly) {
+            log.warn("Read-only mode - skipping call to {} with args {}",
+                    pjp.getSignature().getName(), Arrays.toString(pjp.getArgs()));
+            return null;
+        }
+        return pjp.proceed();
+    }
+}

--- a/src/main/java/org/saidone/processors/AddAspectsAndSetPropertiesProcessor.java
+++ b/src/main/java/org/saidone/processors/AddAspectsAndSetPropertiesProcessor.java
@@ -48,9 +48,7 @@ public class AddAspectsAndSetPropertiesProcessor extends AbstractNodeProcessor {
         nodeBodyUpdate.setAspectNames(aspectNames);
         nodeBodyUpdate.setProperties(castToMapOfStringObject((Map<?, ?>) config.getArg("properties")));
         log.debug("updating node --> {} with --> {}", nodeId, nodeBodyUpdate);
-        if (config.getReadOnly() != null && !config.getReadOnly()) {
-            nodesApi.updateNode(nodeId, nodeBodyUpdate, null, null);
-        }
+        nodesApi.updateNode(nodeId, nodeBodyUpdate, null, null);
     }
 
 }

--- a/src/main/java/org/saidone/processors/ChainingNodeProcessor.java
+++ b/src/main/java/org/saidone/processors/ChainingNodeProcessor.java
@@ -58,10 +58,6 @@ public class ChainingNodeProcessor extends AbstractNodeProcessor {
         }
 
         for (var processorConfig : processorConfigs) {
-            // inherit read-only flag if not explicitly set
-            if (processorConfig.getReadOnly() == null) {
-                processorConfig.setReadOnly(config.getReadOnly());
-            }
             var processorName = StringUtils.uncapitalize(processorConfig.getName());
             NodeProcessor processor;
             try {

--- a/src/main/java/org/saidone/processors/DeleteNodeProcessor.java
+++ b/src/main/java/org/saidone/processors/DeleteNodeProcessor.java
@@ -38,9 +38,7 @@ public class DeleteNodeProcessor extends AbstractNodeProcessor {
     @Override
     public void processNode(String nodeId, ProcessorConfig config) {
         log.debug("deleting node --> {}", nodeId);
-        if (config.getReadOnly() != null && !config.getReadOnly()) {
-            nodesApi.deleteNode(nodeId, config.getArg("permanent") != null ? (Boolean) config.getArg("permanent") : false);
-        }
+        nodesApi.deleteNode(nodeId, config.getArg("permanent") != null ? (Boolean) config.getArg("permanent") : false);
     }
 
 }

--- a/src/main/java/org/saidone/processors/MoveNodeProcessor.java
+++ b/src/main/java/org/saidone/processors/MoveNodeProcessor.java
@@ -60,13 +60,11 @@ public class MoveNodeProcessor extends AbstractNodeProcessor {
         }
         moveBody.setTargetParentId(targetParentId);
         log.debug("moving node --> {} to --> {}", nodeId, moveBody.getTargetParentId());
-        if (config.getReadOnly() != null && !config.getReadOnly()) {
-            try {
-                nodesApi.moveNode(nodeId, moveBody, null, null);
-            } catch (FeignException e) {
-                if (e.status() == HttpStatus.SC_CONFLICT) {
-                    log.warn("a node named {} already exists in destination folder", getNode(nodeId).getName());
-                }
+        try {
+            nodesApi.moveNode(nodeId, moveBody, null, null);
+        } catch (FeignException e) {
+            if (e.status() == HttpStatus.SC_CONFLICT) {
+                log.warn("a node named {} already exists in destination folder", getNode(nodeId).getName());
             }
         }
     }

--- a/src/main/java/org/saidone/processors/SetPermissionsProcessor.java
+++ b/src/main/java/org/saidone/processors/SetPermissionsProcessor.java
@@ -58,9 +58,7 @@ public class SetPermissionsProcessor extends AbstractNodeProcessor {
             var nodeBodyUpdate = new NodeBodyUpdate();
             nodeBodyUpdate.setPermissions(permissionBody);
             log.debug("updating node --> {} with --> {}", nodeId, nodeBodyUpdate);
-            if (config.getReadOnly() != null && !config.getReadOnly()) {
-                nodesApi.updateNode(nodeId, nodeBodyUpdate, null, null);
-            }
+            nodesApi.updateNode(nodeId, nodeBodyUpdate, null, null);
         } else {
             log.warn("permissions not set in config file");
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,7 @@ application:
   queue-size: ${QUEUE_SIZE:1000}
   consumer-threads: ${CONSUMER_THREADS:4}
   consumer-timeout: ${CONSUMER_TIMEOUT:5000}
+  read-only: true
   stats-service:
     enabled: true
     print-interval: 5

--- a/src/test/java/org/alfresco/core/handler/NodesApi.java
+++ b/src/test/java/org/alfresco/core/handler/NodesApi.java
@@ -1,0 +1,5 @@
+package org.alfresco.core.handler;
+
+public interface NodesApi {
+    void deleteNode(String id, Boolean permanent);
+}

--- a/src/test/java/org/alfresco/core/handler/NodesApiImpl.java
+++ b/src/test/java/org/alfresco/core/handler/NodesApiImpl.java
@@ -1,0 +1,9 @@
+package org.alfresco.core.handler;
+
+public class NodesApiImpl implements NodesApi {
+    public boolean called = false;
+    @Override
+    public void deleteNode(String id, Boolean permanent) {
+        called = true;
+    }
+}

--- a/src/test/java/org/saidone/aspects/NodesApiReadOnlyAspectTest.java
+++ b/src/test/java/org/saidone/aspects/NodesApiReadOnlyAspectTest.java
@@ -1,0 +1,35 @@
+package org.saidone.aspects;
+
+import org.alfresco.core.handler.NodesApiImpl;
+import org.alfresco.core.handler.NodesApi;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.aop.framework.ProxyFactory;
+
+public class NodesApiReadOnlyAspectTest {
+
+    @Test
+    public void testDeleteSkippedWhenReadOnly() {
+        NodesApiImpl target = new NodesApiImpl();
+        NodesApiReadOnlyAspect aspect = new NodesApiReadOnlyAspect();
+        ReflectionTestUtils.setField(aspect, "readOnly", true);
+        ProxyFactory pf = new ProxyFactory(target);
+        pf.addAspect(aspect);
+        NodesApi proxy = (NodesApi) pf.getProxy();
+        proxy.deleteNode("id", false);
+        Assertions.assertFalse(target.called, "method should not be called in read-only mode");
+    }
+
+    @Test
+    public void testDeleteProceedsWhenNotReadOnly() {
+        NodesApiImpl target = new NodesApiImpl();
+        NodesApiReadOnlyAspect aspect = new NodesApiReadOnlyAspect();
+        ReflectionTestUtils.setField(aspect, "readOnly", false);
+        ProxyFactory pf = new ProxyFactory(target);
+        pf.addAspect(aspect);
+        NodesApi proxy = (NodesApi) pf.getProxy();
+        proxy.deleteNode("id", false);
+        Assertions.assertTrue(target.called, "method should be called when not read-only");
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,2 +1,3 @@
 application:
   test-root-folder: '/Guest Home'
+  read-only: true


### PR DESCRIPTION
## Summary
- add `application.read-only` property
- block mutating `NodesApi` calls via new `NodesApiReadOnlyAspect`
- remove local readOnly checks from processors
- log read-only state in application runner
- document the new flag in README
- add unit tests for the aspect

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68543078a674832f9fcd2a91d8e1ddaf