### PR TITLE
Improve Javadoc for DownloadNodeProcessor

### DIFF
--- a/src/main/java/org/saidone/processors/DownloadNodeProcessor.java
+++ b/src/main/java/org/saidone/processors/DownloadNodeProcessor.java
@@ -55,15 +55,31 @@ import java.util.List;
 @Slf4j
 public class DownloadNodeProcessor extends AbstractNodeProcessor {
 
+    /**
+     * Name of the processor configuration argument that defines the output directory.
+     */
     private static final String OUTPUT_DIR_ARG = "output-dir";
+
+    /**
+     * Extension used for metadata files written next to each node's binary content.
+     */
     private static final String METADATA_FILE_SUFFIX = ".metadata.properties.xml";
+
+    /**
+     * Preconfigured {@link XmlMapper} instance used to serialize properties to XML.
+     */
     private static final XmlMapper XML_MAPPER = XmlMapper.builder()
             .enable(ToXmlGenerator.Feature.WRITE_XML_DECLARATION)
             .enable(SerializationFeature.INDENT_OUTPUT)
             .build();
 
     /**
-     * Downloads a single node.
+     * Downloads the content and metadata of the node identified by {@code nodeId}.
+     *
+     * <p>The node is fetched from Alfresco with its properties and path
+     * information. A folder mirroring the node's repository path is then created
+     * under the configured output directory. The node's metadata and binary
+     * content are written into this folder.</p>
      *
      * @param nodeId id of the node to download
      * @param config processor configuration containing the {@code output-dir}
@@ -86,6 +102,9 @@ public class DownloadNodeProcessor extends AbstractNodeProcessor {
     /**
      * Resolves the output directory from the processor configuration.
      *
+     * <p>The directory path is read from the argument named by
+     * {@link #OUTPUT_DIR_ARG}. Leading and trailing white spaces are trimmed.</p>
+     *
      * @param config processor configuration
      * @return the output directory as a string
      * @throws IllegalArgumentException if the argument is missing or blank
@@ -101,6 +120,9 @@ public class DownloadNodeProcessor extends AbstractNodeProcessor {
     /**
      * Creates the directory structure for the node inside the output directory.
      *
+     * <p>The returned path points to the folder that will contain the node's
+     * binary content and metadata.</p>
+     *
      * @param outputDirString configured output directory
      * @param nodePath        path of the node relative to the repository
      * @return the created directory
@@ -114,6 +136,10 @@ public class DownloadNodeProcessor extends AbstractNodeProcessor {
 
     /**
      * Writes node metadata to a {@code .properties.xml} file.
+     *
+     * <p>The method collects all node properties and enriches them with a few
+     * additional entries such as type, aspects and creation date before
+     * serializing them to XML.</p>
      *
      * @param node            the node whose metadata is to be saved
      * @param destinationPath directory where the metadata file is created
@@ -134,6 +160,10 @@ public class DownloadNodeProcessor extends AbstractNodeProcessor {
     /**
      * Writes the binary content of the given node to the specified destination path.
      *
+     * <p>If the node is a folder, the corresponding directory structure is created
+     * without writing any content. Otherwise the node content is downloaded and
+     * stored using the node's name.</p>
+     *
      * @param node            the node whose content is to be saved
      * @param destinationPath the folder where the content will be stored
      * @throws IOException if an error occurs during writing the file
@@ -153,7 +183,7 @@ public class DownloadNodeProcessor extends AbstractNodeProcessor {
     }
 
     /**
-     * Retrieves the binary content of a node.
+     * Retrieves the binary content of a node using the {@link #nodesApi}.
      *
      * @param nodeId id of the node
      * @return byte array representing the content or an empty array if the
@@ -174,7 +204,8 @@ public class DownloadNodeProcessor extends AbstractNodeProcessor {
     }
 
     /**
-     * Serializes Alfresco properties to an XML string using {@link XmlMapper}.
+     * Serializes Alfresco properties to an XML string using the configured
+     * {@link XmlMapper}.
      *
      * @param properties properties to serialize
      * @return XML representation of the properties
@@ -185,7 +216,7 @@ public class DownloadNodeProcessor extends AbstractNodeProcessor {
     }
 
     /**
-     * Writes a string to the specified file using UTF-8 encoding.
+     * Writes a string to the specified file using {@link StandardCharsets#UTF_8}.
      *
      * @param path    output file path
      * @param content content to write


### PR DESCRIPTION
## Summary
- expand class and method level documentation for `DownloadNodeProcessor`
- document configuration constants

## Testing
- `mvn -q -DskipTests=true package` *(fails: `mvn` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687f6538091c832fa7452b0b9491b0d6