### PR TITLE
Fix javadoc placement

### DIFF
--- a/src/main/java/org/saidone/collectors/AbstractNodeCollector.java
+++ b/src/main/java/org/saidone/collectors/AbstractNodeCollector.java
@@ -36,13 +36,15 @@ public abstract class AbstractNodeCollector implements NodeCollector {
     @Autowired
     LinkedBlockingQueue<String> queue;
 
-    @SneakyThrows
     /**
-     * Collects nodes asynchronously by delegating to {@link #collectNodes(CollectorConfig)}.
+     * Collects nodes asynchronously by delegating to
+     * {@link #collectNodes(CollectorConfig)}.
      *
      * @param config collector configuration
      * @return future representing the asynchronous task
      */
+    @SneakyThrows
+    @Override
     public CompletableFuture<Void> collect(CollectorConfig config) {
         return CompletableFuture.runAsync(() -> collectNodes(config));
     }


### PR DESCRIPTION
## Summary
- fix javadoc placement in `AbstractNodeCollector`

## Testing
- `mvn -q javadoc:javadoc` *(fails: Could not resolve parent POM)*
- `mvn -q test` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687f676cd31c832fa82e8bf07c76b11d