### PR TITLE
Fix javadoc placement

### DIFF
--- a/src/main/java/org/saidone/model/alfresco/ContentModel.java
+++ b/src/main/java/org/saidone/model/alfresco/ContentModel.java
@@ -18,10 +18,10 @@
 
 package org.saidone.model.alfresco;
 
-@SuppressWarnings("unused")
 /**
  * Constants for the Alfresco public content model.
  */
+@SuppressWarnings("unused")
 public interface ContentModel {
 
     String CM_URI = "http://www.alfresco.org/model/content/1.0";


### PR DESCRIPTION
## Summary
- fix javadoc on `ContentModel` so it attaches to the interface

## Testing
- `mvn -B -DskipTests -Dlicense.skip=true clean package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f844f4bdc832f92d76c5c31a74417