### PR TITLE
Improve NodesApiReadOnlyAspect Javadoc

### DIFF
--- a/src/main/java/org/saidone/aspects/NodesApiReadOnlyAspect.java
+++ b/src/main/java/org/saidone/aspects/NodesApiReadOnlyAspect.java
@@ -29,18 +29,23 @@ import org.springframework.stereotype.Component;
 import java.util.Arrays;
 
 /**
- * Aspect that prevents write operations on Alfresco when the application
- * is configured in read-only mode.
+ * Aspect that intercepts write operations executed through Alfresco's
+ * {@link org.alfresco.core.handler.NodesApi}.
+ *
+ * <p>When {@code application.read-only} is set to {@code true} any intercepted
+ * invocation originating from the {@code org.saidone.processors} package is
+ * skipped and a warning is logged.</p>
  */
 @Aspect
 @Component
 @Slf4j
 public class NodesApiReadOnlyAspect {
 
+    /** Whether the application runs in read-only mode. */
     @Value("${application.read-only:true}")
     private boolean readOnly;
 
-    // Define the package prefix for which enforcement applies
+    /** Package prefix for which enforcement applies. */
     private static final String ENFORCED_PACKAGE = "org.saidone.processors";
 
     @Around("""
@@ -52,6 +57,13 @@ public class NodesApiReadOnlyAspect {
             execution(* org.alfresco.core.handler.NodesApi.unlock*(..)) ||
             execution(* org.alfresco.core.handler.NodesApi.update*(..))
             """)
+    /**
+     * Around advice enforcing read-only mode for write operations.
+     *
+     * @param pjp the intercepted join point
+     * @return the result of the original invocation, or {@code null} when skipped
+     * @throws Throwable if the underlying method throws any exception
+     */
     public Object enforceReadOnly(ProceedingJoinPoint pjp) throws Throwable {
         // Inspect the call stack to find the caller class
         val stack = Thread.currentThread().getStackTrace();


### PR DESCRIPTION
## Summary
- clarify class level javadoc
- document `readOnly` field and `ENFORCED_PACKAGE` constant
- document `enforceReadOnly` advice

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68807aad956c832f991918fcd13da036